### PR TITLE
Adds a constructor that takes a VectorClock to RiakObject

### DIFF
--- a/src/com/trifork/riak/RiakObject.java
+++ b/src/com/trifork/riak/RiakObject.java
@@ -77,6 +77,13 @@ public class RiakObject {
 		}
 	}
 
+    public RiakObject(ByteString vclock, ByteString bucket, ByteString key, ByteString content) {
+		this.bucket = bucket;
+		this.key = key;
+		this.value = content;
+        this.vclock = vclock;
+	}
+
 	public RiakObject(ByteString bucket, ByteString key, ByteString content) {
 		this.bucket = bucket;
 		this.key = key;
@@ -121,6 +128,9 @@ public class RiakObject {
 		return vclock;
 	}
 
+    public ByteString getValue(){
+        return value;
+    }
 
 	RpbContent buildContent() {
 		Builder b = 


### PR DESCRIPTION
This is needed when you are rapidly updating a value for a single key in a single bucket and reading it back, even in a single thread you will see inconsistent data unless you set the vclock of the previous version on the new version
